### PR TITLE
Set k8s cpu and memory resource limits

### DIFF
--- a/deploy/local/deployment.yml
+++ b/deploy/local/deployment.yml
@@ -28,3 +28,10 @@ spec:
               value: top secret k8s
           initialDelaySeconds: 3
           periodSeconds: 3
+        resources:
+          requests:
+            memory: "64Mi"
+            cpu: "250m"
+          limits:
+            memory: "128Mi"
+            cpu: "500m"


### PR DESCRIPTION
Its a good practice to set resource limits in kubernetes to avoid
let kubernetes manage the cpu and memory resources of a cluster
properly.

The values are just kind of defaults and has to be adjusted after
profiling or monitoring experiences of the service.